### PR TITLE
Fix whitespace in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
- - package-ecosystem: "docker"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
There is yaml parser error in the dependabot.yml. A missing whitespace.

This PR fixes that.