### PR TITLE
Bump Nodejs to 22 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:18-alpine AS base
+FROM node:22.12-alpine3.20 AS base
 
 
-FROM node:18-alpine AS deps
+FROM base AS deps
 WORKDIR /app
 
 COPY kraken-webui-app/package.json kraken-webui-app/package-lock.json* ./


### PR DESCRIPTION
This PR supersedes https://github.com/TU-Darmstadt-APQ/kraken_webui/pull/21

I would prefer using node 22 instead of 23 as 23 is the current dev branch. Additionally, we already have the type dependencies for 22 in our package.json, so we definitely need to bump version 18.