### PR TITLE
Bump Alpine Docker image to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS base
+FROM node:22.12.0-alpine3.21 AS base
 
 
 FROM base AS deps


### PR DESCRIPTION
This PR bumps the alpine base image to 3.21, keeping node at 22.