### PR TITLE
Run the linter and prettier in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         run: npx eslint .
 
   prettier:
-    needs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
I have changed the CI in such a way that prettier and ESlint run in parallel instead of consecutive tasks. This speeds up the CI. I reckon ESlint and prettier have no logical dependency.