### PR TITLE
Run the linter only on changed files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Run ESLint
-        run: npx eslint $(git diff --name-only HEAD^ --diff-filter d)
+        run: npx eslint --no-warn-ignored $(git diff --name-only HEAD^ --diff-filter d)
 
   prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR is a follow up to d98c550 and changes the CI behaviour to only lint changed files.

When reviewing #145 I realized that adding or changing linter rules will immediately cause the linter to error out (obviously). Since the linting stage is a requirement for PRs, it means that any change to the linter must always include a boatload of updated files, putting the burden on the person suggesting updated linting rules.

The pre-commit rules also apply the same logic as this PR since #137. This means that a commit may pass locally but be rejected by the CI.

The PR also adds the `--no-warn-ignored` flag to suppress a warning when files on the ignore list are passed the linter. See https://github.com/eslint/rfcs/tree/main/designs/2022-supress-ignored-file-warnings for details.