### PR TITLE
fix: removed dbconnecor call in layout.tsx

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "@/globals.css";
-import DBConnector from "@/components/mongodb/DBConnector";
 import React from "react"; // Add import for React
 
 const geistSans = localFont({
@@ -31,7 +30,6 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
-        <DBConnector />
       </body>
     </html>
   );

--- a/src/components/mongodb/DBConnector.tsx
+++ b/src/components/mongodb/DBConnector.tsx
@@ -58,6 +58,7 @@ export async function getAllDocuments(): Promise<Array<tinkerforgeDTO>> {
   const sensors =
     await database.collection<tinkerforgeEntity>("TinkerforgeSensor");
   let allDocs = await sensors.find({}).toArray();
+  console.log(allDocs);
 
   return allDocs.map(function (doc) {
     return tinkerforgeDTO.convertFromEntity(doc);


### PR DESCRIPTION
Removing `<DBConnector />` Tag from @/app/layout.tsx because DBConnector is loaded dynamically which causes a warning in the build process that the index cannot be statically built.