### PR TITLE
MkDocs layout update

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,9 +15,19 @@ theme:
     - content.code.annotate # Annotations for code comments
     - toc.integrate # Integrate the table of contents into the content
   palette:
-    scheme: slate # Dark theme by default
-    primary: teal # Primary color
-    accent: light blue # Accent color
+    - scheme: default # Light theme by default
+      primary: ultramarine # Primary color ("blue" is better)
+      accent: light blue # Accent color
+      toggle:
+        icon: material/weather-night
+        name: "Switch to dark mode"
+
+    - scheme: slate # Dark theme
+      primary: ultramarine # Primary color ("blue" is better)
+      accent: light blue # Accent color
+      toggle:
+        icon: material/weather-sunny
+        name: "Switch to light mode"
 
 #️ Navigation
 nav:
@@ -41,8 +51,12 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/TU-Darmstadt-APQ/kraken_webui
+  generator: false # Disable "Made with MkDocs" in bottom
   copyright:
     text: "© 2025 Kraken Web UI Documentation"
+
+repo_url: https://github.com/TU-Darmstadt-APQ/kraken_webui
+repo_name: TU-Darmstadt-APQ/kraken_webui
 
 # Deployment Settings
 deploy:


### PR DESCRIPTION
- The main color is now "ultramarine".
- Light and dark modes have been added.
- A link to the GitHub repo has been added (but the number of stars and forks is unavailable because the repo is private).
- The "Made with MkDocs" text at the bottom has been removed.

Now:
![image](https://github.com/user-attachments/assets/44034029-b186-4713-8aa5-2722f0a2c653)
![image](https://github.com/user-attachments/assets/48dd9902-6033-48ff-afe3-e0a33d68556f)

Old:
![image](https://github.com/user-attachments/assets/902bbb86-fea8-46c6-baeb-295478a053ee)
