### PR TITLE
fix: new posts will be added to the top of the list (until the next sorting or search is applied)

### DIFF
--- a/src/components/PostHandler.tsx
+++ b/src/components/PostHandler.tsx
@@ -169,7 +169,7 @@ function PostHandler({ sensors }: { sensors: tinkerforgeDTO[] }) {
    * @param {Post} newPost - The new post to add to the list.
    */
   const createPost = (newPost: Post) => {
-    setPosts([...posts, newPost]);
+    setPosts([newPost, ...posts]);
     setModal(false);
   };
 


### PR DESCRIPTION
when adding a new sensor, they were added to the end of the list, which was convenient when the number of sensors was small.

after adding the database connection, it became necessary to add new sensors to the beginning to improve the user's perception.