### PR TITLE
Revert "[docker] bump node from 22.13.0-alpine3.21 to 23.9.0-alpine3.21"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23.9.0-alpine3.21 AS base
+FROM node:22.13.0-alpine3.21 AS base
 
 
 FROM base AS deps


### PR DESCRIPTION
Reverts TU-Darmstadt-APQ/kraken_webui#258

Edit by @PatrickBaus: @GGalya1 Node 23 has native typescript support. This is a major change and requires heavy rework so this change is postponed. See https://www.totaltypescript.com/typescript-is-coming-to-node-23 for details.